### PR TITLE
feat: implement UpdateCustomFields and ShowCustomFieldsForm (Phase 2)

### DIFF
--- a/functions/show_custom_fields_form/mod.ts
+++ b/functions/show_custom_fields_form/mod.ts
@@ -1,0 +1,449 @@
+/**
+ * ShowCustomFieldsForm function
+ *
+ * Displays a modal form for updating custom fields.
+ * Fetches custom field definitions from team.profile.get API and
+ * creates appropriate input elements based on field types.
+ *
+ * @module functions/show_custom_fields_form
+ */
+
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { initI18n, t } from "../../lib/i18n/mod.ts";
+import type { CustomFieldDefinitionDetail } from "../../lib/types/custom_fields.ts";
+
+/**
+ * Function definition for ShowCustomFieldsForm
+ *
+ * @example
+ * ```typescript
+ * // Use in workflow
+ * workflow.addStep(ShowCustomFieldsFormDefinition, {
+ *   interactivity: workflow.inputs.interactivity,
+ *   user_id: workflow.inputs.user_id,
+ *   channel_id: workflow.inputs.channel_id,
+ * });
+ * ```
+ */
+export const ShowCustomFieldsFormDefinition = DefineFunction({
+  callback_id: "show_custom_fields_form",
+  title: "カスタムフィールド更新フォーム表示",
+  description: "カスタムフィールド更新用のモーダルフォームを表示します",
+  source_file: "functions/show_custom_fields_form/mod.ts",
+  input_parameters: {
+    properties: {
+      interactivity: {
+        type: Schema.slack.types.interactivity,
+        description: "インタラクティブコンテキスト",
+      },
+      user_id: {
+        type: Schema.slack.types.user_id,
+        description: "操作者のユーザーID",
+      },
+      channel_id: {
+        type: Schema.slack.types.channel_id,
+        description: "リクエスト元チャンネル",
+      },
+    },
+    required: ["interactivity", "user_id", "channel_id"],
+  },
+  output_parameters: {
+    properties: {
+      success: {
+        type: Schema.types.boolean,
+        description: "処理成功かどうか",
+      },
+      approval_required: {
+        type: Schema.types.boolean,
+        description: "承認リクエストが送信されたかどうか",
+      },
+      updated_user_id: {
+        type: Schema.slack.types.user_id,
+        description: "更新されたユーザーID",
+      },
+    },
+    required: ["success"],
+  },
+});
+
+/**
+ * Block element type for input blocks
+ */
+interface BlockElement {
+  type: string;
+  block_id: string;
+  optional: boolean;
+  element: Record<string, unknown>;
+  label: {
+    type: string;
+    text: string;
+  };
+  hint?: {
+    type: string;
+    text: string;
+  };
+}
+
+/**
+ * Creates a Block Kit input element based on field type
+ *
+ * @param field - Custom field definition
+ * @param currentValue - Optional current value for the field
+ * @returns Block Kit input block
+ */
+function createFieldInput(
+  field: CustomFieldDefinitionDetail,
+  currentValue?: string,
+): BlockElement {
+  const blockId = `field_${field.id}`;
+  const actionId = `input_${field.id}`;
+
+  switch (field.type) {
+    case "options_list":
+      return {
+        type: "input",
+        block_id: blockId,
+        optional: true,
+        element: {
+          type: "static_select",
+          action_id: actionId,
+          placeholder: {
+            type: "plain_text",
+            text: t("messages.select_field_placeholder"),
+          },
+          options: (field.possible_values || []).map((v) => ({
+            text: { type: "plain_text", text: v },
+            value: v,
+          })),
+          ...(currentValue && {
+            initial_option: {
+              text: { type: "plain_text", text: currentValue },
+              value: currentValue,
+            },
+          }),
+        },
+        label: {
+          type: "plain_text",
+          text: field.label,
+        },
+        ...(field.hint && {
+          hint: {
+            type: "plain_text",
+            text: field.hint,
+          },
+        }),
+      };
+
+    case "date":
+      return {
+        type: "input",
+        block_id: blockId,
+        optional: true,
+        element: {
+          type: "datepicker",
+          action_id: actionId,
+          ...(currentValue && { initial_date: currentValue }),
+        },
+        label: {
+          type: "plain_text",
+          text: field.label,
+        },
+        ...(field.hint && {
+          hint: {
+            type: "plain_text",
+            text: field.hint,
+          },
+        }),
+      };
+
+    case "text":
+    default:
+      return {
+        type: "input",
+        block_id: blockId,
+        optional: true,
+        element: {
+          type: "plain_text_input",
+          action_id: actionId,
+          ...(currentValue && { initial_value: currentValue }),
+        },
+        label: {
+          type: "plain_text",
+          text: field.label,
+        },
+        ...(field.hint && {
+          hint: {
+            type: "plain_text",
+            text: field.hint,
+          },
+        }),
+      };
+  }
+}
+
+/**
+ * team.profile.get API response field type
+ */
+interface ProfileField {
+  id: string;
+  ordering: number;
+  label: string;
+  hint: string;
+  type: string;
+  possible_values: string[] | null;
+  options?: {
+    is_scim: boolean;
+    is_protected: boolean;
+  };
+  is_hidden: boolean;
+  section_id: string;
+}
+
+/**
+ * ShowCustomFieldsForm function implementation
+ *
+ * Displays a modal form for updating custom fields. The form includes:
+ * - Target user selector (defaults to the operator)
+ * - Input fields for each non-hidden, non-protected custom field
+ *
+ * @param inputs - Function inputs
+ * @param inputs.interactivity - Interactivity context for opening modal
+ * @param inputs.user_id - Operator's user ID
+ * @param inputs.channel_id - Source channel ID
+ * @param client - Slack API client
+ * @returns Success status or completed: false to wait for modal submission
+ */
+export default SlackFunction(
+  ShowCustomFieldsFormDefinition,
+  async ({ inputs, client }) => {
+    // Initialize i18n system
+    await initI18n();
+
+    console.log(t("logs.modal_opened"));
+
+    try {
+      // 1. Fetch custom field definitions
+      console.log(t("logs.fetching_custom_fields"));
+      const profileResponse = await client.team.profile.get({});
+      if (!profileResponse.ok) {
+        throw new Error(
+          t("errors.api_call_failed", {
+            error: profileResponse.error ?? t("errors.unknown_error"),
+          }),
+        );
+      }
+
+      // Filter out hidden and protected fields
+      const fields = ((profileResponse.profile?.fields || []) as ProfileField[])
+        .filter((f) => !f.is_hidden && !f.options?.is_protected);
+
+      console.log(t("logs.custom_fields_fetched", { count: fields.length }));
+
+      if (fields.length === 0) {
+        // Show message when no fields are available
+        await client.views.open({
+          trigger_id: inputs.interactivity.interactivity_pointer,
+          view: {
+            type: "modal",
+            title: {
+              type: "plain_text",
+              text: t("messages.custom_fields_form_title"),
+            },
+            close: { type: "plain_text", text: t("messages.close_button") },
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: t("messages.no_custom_fields"),
+                },
+              },
+            ],
+          },
+        });
+        return { outputs: { success: true } };
+      }
+
+      // 2. Build form blocks
+      const blocks: object[] = [
+        {
+          type: "input",
+          block_id: "target_user_block",
+          element: {
+            type: "users_select",
+            action_id: "target_user_select",
+            initial_user: inputs.user_id,
+          },
+          label: {
+            type: "plain_text",
+            text: t("form.target_user_label"),
+          },
+        },
+        { type: "divider" },
+        {
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: `*${t("messages.custom_fields_form_description")}*`,
+          },
+        },
+      ];
+
+      // Add input element for each field
+      for (const field of fields) {
+        blocks.push(
+          createFieldInput(field as unknown as CustomFieldDefinitionDetail),
+        );
+      }
+
+      // 3. Open the modal
+      const viewResponse = await client.views.open({
+        trigger_id: inputs.interactivity.interactivity_pointer,
+        view: {
+          type: "modal",
+          callback_id: "custom_fields_form_modal",
+          private_metadata: JSON.stringify({
+            channel_id: inputs.channel_id,
+            operator_id: inputs.user_id,
+          }),
+          title: {
+            type: "plain_text",
+            text: t("messages.custom_fields_form_title"),
+          },
+          submit: {
+            type: "plain_text",
+            text: t("form.submit_button"),
+          },
+          close: {
+            type: "plain_text",
+            text: t("form.cancel_button"),
+          },
+          blocks,
+        },
+      });
+
+      if (!viewResponse.ok) {
+        throw new Error(
+          t("errors.modal_open_failed", {
+            error: viewResponse.error ?? t("errors.unknown_error"),
+          }),
+        );
+      }
+
+      // Return completed: false to wait for modal submission
+      return { completed: false };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("ShowCustomFieldsForm error:", message);
+      return { error: message };
+    }
+  },
+)
+  // Modal submission handler
+  .addViewSubmissionHandler(
+    ["custom_fields_form_modal"],
+    async ({ view, client, env }) => {
+      await initI18n();
+
+      const metadata = JSON.parse(view.private_metadata || "{}");
+      const values = view.state.values;
+
+      // Get target user
+      const targetUserId = values.target_user_block?.target_user_select
+        ?.selected_user;
+      if (!targetUserId) {
+        return {
+          response_action: "errors",
+          errors: { target_user_block: t("errors.user_not_selected") },
+        };
+      }
+
+      // Collect field updates
+      const fieldUpdates: Record<string, string> = {};
+      for (const [blockId, blockValue] of Object.entries(values)) {
+        if (blockId.startsWith("field_")) {
+          const fieldId = blockId.replace("field_", "");
+          const actionId = `input_${fieldId}`;
+          const element = (blockValue as Record<string, unknown>)[actionId] as {
+            selected_option?: { value: string };
+            selected_date?: string;
+            value?: string;
+          };
+
+          let value: string | undefined;
+          if (element?.selected_option?.value) {
+            value = element.selected_option.value;
+          } else if (element?.selected_date) {
+            value = element.selected_date;
+          } else if (element?.value) {
+            value = element.value;
+          }
+
+          if (value) {
+            fieldUpdates[fieldId] = value;
+          }
+        }
+      }
+
+      if (Object.keys(fieldUpdates).length === 0) {
+        return {
+          response_action: "errors",
+          errors: { target_user_block: t("errors.no_fields_to_update") },
+        };
+      }
+
+      // Get Admin User Token
+      const adminToken = env.SLACK_ADMIN_USER_TOKEN;
+      if (!adminToken) {
+        return {
+          response_action: "errors",
+          errors: { target_user_block: t("errors.missing_admin_token") },
+        };
+      }
+
+      // Build fields object for API
+      const fields: Record<string, { value: string; alt: string }> = {};
+      for (const [fieldId, value] of Object.entries(fieldUpdates)) {
+        fields[fieldId] = { value, alt: "" };
+      }
+
+      // Update custom fields via API
+      console.log(t("logs.updating_custom_fields"));
+      const updateResponse = await fetch(
+        "https://slack.com/api/users.profile.set",
+        {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${adminToken}`,
+            "Content-Type": "application/json; charset=utf-8",
+          },
+          body: JSON.stringify({
+            user: targetUserId,
+            profile: { fields },
+          }),
+        },
+      );
+
+      const result = await updateResponse.json();
+      if (!result.ok) {
+        return {
+          response_action: "errors",
+          errors: {
+            target_user_block: t("errors.custom_field_update_failed", {
+              error: result.error,
+            }),
+          },
+        };
+      }
+
+      console.log(t("logs.custom_fields_updated"));
+
+      // Send success message to operator
+      await client.chat.postMessage({
+        channel: metadata.operator_id,
+        text: t("messages.custom_fields_updated"),
+      });
+
+      return { response_action: "clear" };
+    },
+  );

--- a/functions/show_custom_fields_form/test.ts
+++ b/functions/show_custom_fields_form/test.ts
@@ -1,0 +1,382 @@
+/**
+ * Tests for ShowCustomFieldsForm function
+ *
+ * @module functions/show_custom_fields_form/test
+ */
+
+import { assertEquals } from "std/testing/asserts.ts";
+import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import * as mf from "mock-fetch/mod.ts";
+import handler, { ShowCustomFieldsFormDefinition } from "./mod.ts";
+import { initI18n } from "../../lib/i18n/mod.ts";
+
+// Initialize i18n before tests
+await initI18n();
+
+// Install mock fetch
+mf.install();
+
+const { createContext } = SlackFunctionTester("show_custom_fields_form");
+
+/**
+ * Mock team.profile.get API response with fields
+ */
+function mockTeamProfileGet(
+  fields: Array<{
+    id: string;
+    label: string;
+    type: string;
+    hint?: string;
+    is_hidden?: boolean;
+    is_protected?: boolean;
+    possible_values?: string[];
+  }>,
+) {
+  return {
+    ok: true,
+    profile: {
+      fields: fields.map((f) => ({
+        id: f.id,
+        ordering: 0,
+        label: f.label,
+        hint: f.hint ?? "",
+        type: f.type,
+        possible_values: f.possible_values ?? null,
+        options: {
+          is_scim: false,
+          is_protected: f.is_protected ?? false,
+        },
+        is_hidden: f.is_hidden ?? false,
+        section_id: "S001",
+      })),
+      sections: [],
+    },
+  };
+}
+
+/**
+ * Mock team.profile.get API error response
+ */
+function mockTeamProfileGetError(error: string) {
+  return {
+    ok: false,
+    error,
+  };
+}
+
+/**
+ * Mock views.open API response
+ */
+function mockViewsOpen(success: boolean, viewId?: string) {
+  return {
+    ok: success,
+    view: success ? { id: viewId ?? "V12345" } : undefined,
+    error: success ? undefined : "trigger_expired",
+  };
+}
+
+Deno.test("ShowCustomFieldsForm - 関数定義が正しく設定されている", () => {
+  assertEquals(
+    ShowCustomFieldsFormDefinition.definition.callback_id,
+    "show_custom_fields_form",
+  );
+  assertEquals(
+    ShowCustomFieldsFormDefinition.definition.title,
+    "カスタムフィールド更新フォーム表示",
+  );
+});
+
+Deno.test("ShowCustomFieldsForm - カスタムフィールドがある場合はフォームを表示する", async () => {
+  // Mock team.profile.get
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(
+        mockTeamProfileGet([
+          { id: "Xf123", label: "部門", type: "text", hint: "所属部門" },
+          {
+            id: "Xf456",
+            label: "役職",
+            type: "options_list",
+            possible_values: ["Manager", "Engineer"],
+          },
+        ]),
+      ),
+    );
+  });
+
+  // Mock views.open
+  mf.mock("POST@/api/views.open", () => {
+    return new Response(JSON.stringify(mockViewsOpen(true, "V12345")));
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  // Should return completed: false to wait for form submission
+  assertEquals(result.completed, false);
+  assertEquals(result.error, undefined);
+
+  mf.reset();
+});
+
+Deno.test("ShowCustomFieldsForm - カスタムフィールドがない場合はメッセージを表示する", async () => {
+  // Mock team.profile.get with no fields
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(mockTeamProfileGet([])),
+    );
+  });
+
+  // Mock views.open for the "no fields" message
+  mf.mock("POST@/api/views.open", () => {
+    return new Response(JSON.stringify(mockViewsOpen(true, "V12345")));
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  // Should return success with outputs (not completed: false)
+  assertEquals(result.outputs?.success, true);
+
+  mf.reset();
+});
+
+Deno.test("ShowCustomFieldsForm - 非表示フィールドはフィルタリングされる", async () => {
+  // Mock team.profile.get with hidden field
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(
+        mockTeamProfileGet([
+          { id: "Xf123", label: "部門", type: "text", is_hidden: true },
+        ]),
+      ),
+    );
+  });
+
+  // Mock views.open for the "no fields" message
+  mf.mock("POST@/api/views.open", () => {
+    return new Response(JSON.stringify(mockViewsOpen(true, "V12345")));
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  // Should return success (no visible fields = show message)
+  assertEquals(result.outputs?.success, true);
+
+  mf.reset();
+});
+
+Deno.test("ShowCustomFieldsForm - 保護されたフィールドはフィルタリングされる", async () => {
+  // Mock team.profile.get with protected field
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(
+        mockTeamProfileGet([
+          { id: "Xf123", label: "部門", type: "text", is_protected: true },
+        ]),
+      ),
+    );
+  });
+
+  // Mock views.open for the "no fields" message
+  mf.mock("POST@/api/views.open", () => {
+    return new Response(JSON.stringify(mockViewsOpen(true, "V12345")));
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  // Should return success (no visible fields = show message)
+  assertEquals(result.outputs?.success, true);
+
+  mf.reset();
+});
+
+Deno.test("ShowCustomFieldsForm - team.profile.get失敗時にエラーを返す", async () => {
+  // Mock team.profile.get error
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(mockTeamProfileGetError("team_not_found")),
+    );
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(typeof result.error, "string");
+
+  mf.reset();
+});
+
+Deno.test("ShowCustomFieldsForm - views.open失敗時にエラーを返す", async () => {
+  // Mock team.profile.get
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(
+        mockTeamProfileGet([
+          { id: "Xf123", label: "部門", type: "text" },
+        ]),
+      ),
+    );
+  });
+
+  // Mock views.open failure
+  mf.mock("POST@/api/views.open", () => {
+    return new Response(JSON.stringify(mockViewsOpen(false)));
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(typeof result.error, "string");
+
+  mf.reset();
+});
+
+Deno.test("ShowCustomFieldsForm - dateタイプのフィールドが正しく処理される", async () => {
+  // Mock team.profile.get with date field
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(
+        mockTeamProfileGet([
+          { id: "Xf789", label: "入社日", type: "date", hint: "入社年月日" },
+        ]),
+      ),
+    );
+  });
+
+  // Mock views.open
+  mf.mock("POST@/api/views.open", () => {
+    return new Response(JSON.stringify(mockViewsOpen(true, "V12345")));
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  // Should return completed: false to wait for form submission
+  assertEquals(result.completed, false);
+  assertEquals(result.error, undefined);
+
+  mf.reset();
+});
+
+Deno.test("ShowCustomFieldsForm - options_listタイプのフィールドが正しく処理される", async () => {
+  // Mock team.profile.get with options_list field
+  mf.mock("POST@/api/team.profile.get", () => {
+    return new Response(
+      JSON.stringify(
+        mockTeamProfileGet([
+          {
+            id: "Xf456",
+            label: "役職",
+            type: "options_list",
+            possible_values: ["Manager", "Engineer", "Designer"],
+          },
+        ]),
+      ),
+    );
+  });
+
+  // Mock views.open
+  mf.mock("POST@/api/views.open", () => {
+    return new Response(JSON.stringify(mockViewsOpen(true, "V12345")));
+  });
+
+  const context = createContext({
+    inputs: {
+      interactivity: {
+        interactivity_pointer: "trigger_12345",
+        interactor: { id: "U001", secret: "secret" },
+      },
+      user_id: "U001",
+      channel_id: "C001",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  // Should return completed: false to wait for form submission
+  assertEquals(result.completed, false);
+  assertEquals(result.error, undefined);
+
+  mf.reset();
+});

--- a/functions/update_custom_fields/mod.ts
+++ b/functions/update_custom_fields/mod.ts
@@ -1,0 +1,187 @@
+/**
+ * UpdateCustomFields function
+ *
+ * Updates custom fields for a specified user using the Admin User Token.
+ * Uses the users.profile.set API with the fields object.
+ *
+ * @module functions/update_custom_fields
+ */
+
+import { DefineFunction, Schema, SlackFunction } from "deno-slack-sdk/mod.ts";
+import { initI18n, t } from "../../lib/i18n/mod.ts";
+import { userIdSchema } from "../../lib/validation/schemas.ts";
+
+/**
+ * Function definition for UpdateCustomFields
+ *
+ * @example
+ * ```typescript
+ * // Use in workflow
+ * const updateStep = workflow.addStep(UpdateCustomFieldsDefinition, {
+ *   target_user_id: workflow.inputs.user_id,
+ *   field_updates: JSON.stringify({ "Xf123": "New Value" }),
+ * });
+ * ```
+ */
+export const UpdateCustomFieldsDefinition = DefineFunction({
+  callback_id: "update_custom_fields",
+  title: "カスタムフィールド更新",
+  description: "ユーザーのカスタムフィールドを更新します",
+  source_file: "functions/update_custom_fields/mod.ts",
+  input_parameters: {
+    properties: {
+      target_user_id: {
+        type: Schema.slack.types.user_id,
+        description: "更新対象のユーザーID",
+      },
+      field_updates: {
+        type: Schema.types.string,
+        description: "更新するフィールドのJSON（{field_id: value}形式）",
+      },
+    },
+    required: ["target_user_id", "field_updates"],
+  },
+  output_parameters: {
+    properties: {
+      success: {
+        type: Schema.types.boolean,
+        description: "更新成功かどうか",
+      },
+      updated_fields: {
+        type: Schema.types.array,
+        items: { type: Schema.types.string },
+        description: "更新されたフィールドID一覧",
+      },
+      error: {
+        type: Schema.types.string,
+        description: "エラーメッセージ（失敗時）",
+      },
+    },
+    required: ["success"],
+  },
+});
+
+/**
+ * users.profile.set API response type
+ */
+interface ProfileSetResponse {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Updates custom fields using Admin User Token
+ *
+ * @param adminToken - Admin User Token (xoxp-)
+ * @param userId - Target user ID
+ * @param fieldUpdates - Map of field ID to new value
+ * @returns API response
+ */
+async function updateCustomFieldsWithAdminApi(
+  adminToken: string,
+  userId: string,
+  fieldUpdates: Record<string, string>,
+): Promise<ProfileSetResponse> {
+  // Build fields object for API
+  const fields: Record<string, { value: string; alt: string }> = {};
+  for (const [fieldId, value] of Object.entries(fieldUpdates)) {
+    fields[fieldId] = { value, alt: "" };
+  }
+
+  const response = await fetch("https://slack.com/api/users.profile.set", {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${adminToken}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify({
+      user: userId,
+      profile: { fields },
+    }),
+  });
+
+  return await response.json() as ProfileSetResponse;
+}
+
+/**
+ * UpdateCustomFields function implementation
+ *
+ * Updates custom fields for the specified user. Requires Admin User Token
+ * to update fields for other users.
+ *
+ * @param inputs - Function inputs
+ * @param inputs.target_user_id - Target user ID to update
+ * @param inputs.field_updates - JSON string of field updates
+ * @param env - Environment variables
+ * @returns Update result with success status and updated field IDs
+ */
+export default SlackFunction(
+  UpdateCustomFieldsDefinition,
+  async ({ inputs, env }) => {
+    // Initialize i18n system
+    await initI18n();
+
+    console.log(t("logs.updating_custom_fields"), {
+      userId: inputs.target_user_id,
+    });
+
+    try {
+      // Validate user ID
+      userIdSchema.parse(inputs.target_user_id);
+
+      // Get Admin User Token
+      const adminToken = env.SLACK_ADMIN_USER_TOKEN;
+      if (!adminToken) {
+        throw new Error(t("errors.missing_admin_token"));
+      }
+
+      // Parse field updates JSON
+      let fieldUpdates: Record<string, string>;
+      try {
+        fieldUpdates = JSON.parse(inputs.field_updates);
+      } catch {
+        throw new Error(t("errors.invalid_json_format"));
+      }
+
+      // Validate there are fields to update
+      if (Object.keys(fieldUpdates).length === 0) {
+        throw new Error(t("errors.no_fields_to_update"));
+      }
+
+      // Update custom fields
+      const result = await updateCustomFieldsWithAdminApi(
+        adminToken,
+        inputs.target_user_id,
+        fieldUpdates,
+      );
+
+      if (!result.ok) {
+        throw new Error(
+          t("errors.custom_field_update_failed", {
+            error: result.error ?? t("errors.unknown_error"),
+          }),
+        );
+      }
+
+      console.log(t("logs.custom_fields_updated"));
+
+      return {
+        outputs: {
+          success: true,
+          updated_fields: Object.keys(fieldUpdates),
+        },
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("UpdateCustomFields error:", message);
+
+      return {
+        outputs: {
+          success: false,
+          updated_fields: [],
+          error: message,
+        },
+      };
+    }
+  },
+);

--- a/functions/update_custom_fields/test.ts
+++ b/functions/update_custom_fields/test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for UpdateCustomFields function
+ *
+ * @module functions/update_custom_fields/test
+ */
+
+import { assertEquals } from "std/testing/asserts.ts";
+import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import * as mf from "mock-fetch/mod.ts";
+import handler, { UpdateCustomFieldsDefinition } from "./mod.ts";
+import { initI18n } from "../../lib/i18n/mod.ts";
+
+// Initialize i18n before tests
+await initI18n();
+
+// Install mock fetch
+mf.install();
+
+const { createContext } = SlackFunctionTester("update_custom_fields");
+
+/**
+ * Mock users.profile.set API success response
+ */
+function mockProfileSetSuccess() {
+  return {
+    ok: true,
+    profile: {
+      fields: {
+        Xf123: { value: "New Value", alt: "" },
+      },
+    },
+  };
+}
+
+/**
+ * Mock API error response
+ */
+function mockApiError(errorCode: string) {
+  return {
+    ok: false,
+    error: errorCode,
+  };
+}
+
+Deno.test("UpdateCustomFields - 関数定義が正しく設定されている", () => {
+  assertEquals(
+    UpdateCustomFieldsDefinition.definition.callback_id,
+    "update_custom_fields",
+  );
+  assertEquals(
+    UpdateCustomFieldsDefinition.definition.title,
+    "カスタムフィールド更新",
+  );
+});
+
+Deno.test("UpdateCustomFields - カスタムフィールドを正常に更新できる", async () => {
+  mf.mock("POST@/api/users.profile.set", () => {
+    return new Response(JSON.stringify(mockProfileSetSuccess()));
+  });
+
+  const context = createContext({
+    inputs: {
+      target_user_id: "U0812GLUZD2",
+      field_updates: JSON.stringify({ Xf123: "New Value" }),
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, true);
+  assertEquals(result.outputs?.updated_fields?.length, 1);
+  assertEquals(result.outputs?.updated_fields?.[0], "Xf123");
+
+  mf.reset();
+});
+
+Deno.test("UpdateCustomFields - 複数フィールドを更新できる", async () => {
+  mf.mock("POST@/api/users.profile.set", () => {
+    return new Response(JSON.stringify(mockProfileSetSuccess()));
+  });
+
+  const context = createContext({
+    inputs: {
+      target_user_id: "U0812GLUZD2",
+      field_updates: JSON.stringify({
+        Xf123: "Value1",
+        Xf456: "Value2",
+        Xf789: "Value3",
+      }),
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, true);
+  assertEquals(result.outputs?.updated_fields?.length, 3);
+
+  mf.reset();
+});
+
+Deno.test("UpdateCustomFields - Admin Tokenがない場合はエラーを返す", async () => {
+  const context = createContext({
+    inputs: {
+      target_user_id: "U0812GLUZD2",
+      field_updates: JSON.stringify({ Xf123: "New Value" }),
+    },
+    env: {},
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, false);
+  assertEquals(result.outputs?.updated_fields?.length, 0);
+  assertEquals(typeof result.outputs?.error, "string");
+
+  mf.reset();
+});
+
+Deno.test("UpdateCustomFields - 無効なJSON形式の場合はエラーを返す", async () => {
+  const context = createContext({
+    inputs: {
+      target_user_id: "U0812GLUZD2",
+      field_updates: "invalid json",
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, false);
+  assertEquals(result.outputs?.updated_fields?.length, 0);
+  assertEquals(typeof result.outputs?.error, "string");
+
+  mf.reset();
+});
+
+Deno.test("UpdateCustomFields - 空のフィールド更新の場合はエラーを返す", async () => {
+  const context = createContext({
+    inputs: {
+      target_user_id: "U0812GLUZD2",
+      field_updates: JSON.stringify({}),
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, false);
+  assertEquals(result.outputs?.updated_fields?.length, 0);
+  assertEquals(typeof result.outputs?.error, "string");
+
+  mf.reset();
+});
+
+Deno.test("UpdateCustomFields - APIエラー時はエラーを返す", async () => {
+  mf.mock("POST@/api/users.profile.set", () => {
+    return new Response(JSON.stringify(mockApiError("user_not_found")));
+  });
+
+  const context = createContext({
+    inputs: {
+      target_user_id: "U0812GLUZD2",
+      field_updates: JSON.stringify({ Xf123: "New Value" }),
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, false);
+  assertEquals(result.outputs?.updated_fields?.length, 0);
+  assertEquals(typeof result.outputs?.error, "string");
+  assertEquals(result.outputs?.error?.includes("user_not_found"), true);
+
+  mf.reset();
+});
+
+Deno.test("UpdateCustomFields - レート制限エラーを適切に処理する", async () => {
+  mf.mock("POST@/api/users.profile.set", () => {
+    return new Response(JSON.stringify(mockApiError("rate_limited")));
+  });
+
+  const context = createContext({
+    inputs: {
+      target_user_id: "U0812GLUZD2",
+      field_updates: JSON.stringify({ Xf123: "New Value" }),
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, false);
+  assertEquals(result.outputs?.error?.includes("rate_limited"), true);
+
+  mf.reset();
+});
+
+Deno.test("UpdateCustomFields - 無効なユーザーIDの場合はエラーを返す", async () => {
+  const context = createContext({
+    inputs: {
+      target_user_id: "invalid_user_id",
+      field_updates: JSON.stringify({ Xf123: "New Value" }),
+    },
+    env: { SLACK_ADMIN_USER_TOKEN: "xoxp-test-token" },
+  });
+
+  const result = await handler(context);
+
+  assertEquals(result.outputs?.success, false);
+  assertEquals(typeof result.outputs?.error, "string");
+
+  mf.reset();
+});

--- a/locales/en.json
+++ b/locales/en.json
@@ -27,6 +27,8 @@
     "invalid_type": "Invalid type: expected {expected}, got {actual}",
     "empty_value": "Value cannot be empty",
     "invalid_format": "Invalid format for {field}: expected {pattern}",
+    "invalid_json_format": "Invalid JSON format",
+    "user_not_selected": "Please select a target user",
     "validation": {
       "channel_id_empty": "Channel ID cannot be empty",
       "channel_id_format": "Channel ID must start with 'C' followed by uppercase alphanumeric characters",
@@ -61,7 +63,8 @@
     "field_change": "• {field}: {old} → {new}",
     "loading_form": "⏳ Loading form...",
     "processing": "Processing...",
-    "success": "Operation completed successfully"
+    "success": "Operation completed successfully",
+    "close_button": "Close"
   },
   "form": {
     "title": "Update Profile",
@@ -117,6 +120,8 @@
     "processing_approval": "Processing approval: action={action}, reviewer={reviewer}",
     "fetching_custom_fields": "Fetching custom field definitions...",
     "custom_fields_fetched": "Fetched {count} custom fields",
+    "updating_custom_fields": "Updating custom fields...",
+    "custom_fields_updated": "Custom fields updated successfully",
     "fetching_authorized_users": "Fetching authorized approvers...",
     "authorized_users_fetched": "Found {count} authorized approvers",
     "max_page_limit_reached": "Maximum page limit of {limit} reached while fetching users",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -27,6 +27,8 @@
     "invalid_type": "無効な型: {expected} が期待されましたが、{actual} が取得されました",
     "empty_value": "値を空にすることはできません",
     "invalid_format": "{field} の形式が無効です: {pattern} が期待されています",
+    "invalid_json_format": "無効なJSON形式です",
+    "user_not_selected": "対象ユーザーを選択してください",
     "validation": {
       "channel_id_empty": "チャンネルIDを空にすることはできません",
       "channel_id_format": "チャンネルIDは 'C' で始まり、その後に大文字の英数字が続く必要があります",
@@ -61,7 +63,8 @@
     "field_change": "• {field}: {old} → {new}",
     "loading_form": "⏳ フォームを読み込み中...",
     "processing": "処理中...",
-    "success": "操作が正常に完了しました"
+    "success": "操作が正常に完了しました",
+    "close_button": "閉じる"
   },
   "form": {
     "title": "プロフィールを更新",
@@ -117,6 +120,8 @@
     "processing_approval": "承認を処理中: action={action}, reviewer={reviewer}",
     "fetching_custom_fields": "カスタムフィールド定義を取得中...",
     "custom_fields_fetched": "{count} 個のカスタムフィールドを取得しました",
+    "updating_custom_fields": "カスタムフィールドを更新中...",
+    "custom_fields_updated": "カスタムフィールドが正常に更新されました",
     "fetching_authorized_users": "承認権限のあるユーザーを取得中...",
     "authorized_users_fetched": "{count} 人の承認権限のあるユーザーが見つかりました",
     "max_page_limit_reached": "ユーザー取得時に最大ページ制限 {limit} に達しました",

--- a/manifest.ts
+++ b/manifest.ts
@@ -5,10 +5,9 @@ import { UpdateUserProfileDefinition } from "./functions/update_user_profile/mod
 import { CheckUserPermissionsDefinition } from "./functions/check_user_permissions/mod.ts";
 import { ShowProfileUpdateFormDefinition } from "./functions/show_profile_update_form/mod.ts";
 import { GetAuthorizedApproversDefinition } from "./functions/get_authorized_approvers/mod.ts";
-
-// TODO: Import additional function definitions when implemented
-// import { UpdateCustomFieldsDefinition } from "./functions/update_custom_fields/mod.ts";
-// import { GetCustomFieldDefinitionsDefinition } from "./functions/get_custom_field_definitions/mod.ts";
+import { GetCustomFieldDefinitionsDefinition } from "./functions/get_custom_field_definitions/mod.ts";
+import { UpdateCustomFieldsDefinition } from "./functions/update_custom_fields/mod.ts";
+import { ShowCustomFieldsFormDefinition } from "./functions/show_custom_fields_form/mod.ts";
 
 // Import workflow definitions
 import UpdateProfileWorkflow from "./workflows/update_profile_workflow.ts";
@@ -32,6 +31,9 @@ export default Manifest({
     CheckUserPermissionsDefinition,
     ShowProfileUpdateFormDefinition,
     GetAuthorizedApproversDefinition,
+    GetCustomFieldDefinitionsDefinition,
+    UpdateCustomFieldsDefinition,
+    ShowCustomFieldsFormDefinition,
   ],
   outgoingDomains: [],
   botScopes: [


### PR DESCRIPTION
## Summary
- UpdateCustomFields関数: Admin User Tokenを使用してカスタムフィールドを更新
- ShowCustomFieldsForm関数: モーダルフォーム表示 + ViewSubmissionHandler
- フィールドタイプ別の入力要素サポート（text/options_list/date）
- i18nメッセージ追加（close_button）
- manifest.tsへの関数登録

## Test plan
- [x] deno task check 成功
- [x] deno task lint 成功（33ファイル）
- [x] deno task test 成功（100テスト）
- [x] i18n:check 成功（123キー一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)