### PR TITLE
feat: add before → after diff display to messages

### DIFF
--- a/functions/show_custom_fields_form/mod.ts
+++ b/functions/show_custom_fields_form/mod.ts
@@ -1269,39 +1269,6 @@ export default SlackFunction(
 
       console.log(t("logs.custom_fields_updated"));
 
-      // Update the message to show approval
-      const approvedText = t("messages.request_approved", {
-        approver: reviewerId,
-        requester: requester_id,
-        target: target_user_id,
-      });
-
-      await client.chat.update({
-        channel: body.channel?.id ?? "",
-        ts: body.message?.ts ?? "",
-        blocks: [
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: approvedText,
-            },
-          },
-          {
-            type: "context",
-            elements: [
-              {
-                type: "mrkdwn",
-                text: t("messages.approved_at", {
-                  time: new Date().toISOString(),
-                }),
-              },
-            ],
-          },
-        ],
-        text: approvedText,
-      });
-
       // Build changes text with before → after diff for notification
       const changesText = Object.entries(changes)
         .map(([fieldId, change]) => {
@@ -1320,6 +1287,46 @@ export default SlackFunction(
           }
         })
         .join("\n");
+
+      // Update the message to show approval with changes
+      const approvedText = t("messages.request_approved", {
+        approver: reviewerId,
+        requester: requester_id,
+        target: target_user_id,
+      });
+
+      await client.chat.update({
+        channel: body.channel?.id ?? "",
+        ts: body.message?.ts ?? "",
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: approvedText,
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `*${t("messages.changes_label")}:*\n${changesText}`,
+            },
+          },
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: t("messages.approved_at", {
+                  time: new Date().toISOString(),
+                }),
+              },
+            ],
+          },
+        ],
+        text: approvedText,
+      });
 
       // Notify requester via DM
       await sendDirectMessage(

--- a/functions/show_custom_fields_form/mod.ts
+++ b/functions/show_custom_fields_form/mod.ts
@@ -283,6 +283,14 @@ interface ProfileField {
 }
 
 /**
+ * Field change with old and new values for diff display
+ */
+interface FieldChange {
+  old: string;
+  new: string;
+}
+
+/**
  * Check if user is admin or owner
  */
 async function checkUserPermissions(
@@ -451,13 +459,17 @@ async function sendDirectMessage(
 function buildApprovalMessage(
   requesterId: string,
   targetUserId: string,
-  changes: Record<string, string>,
+  changes: Record<string, FieldChange>,
   fieldLabels: Record<string, string>,
   approverIds?: string[],
 ) {
   const changesText = Object.entries(changes)
-    .map(([fieldId, value]) =>
-      `• *${fieldLabels[fieldId] ?? fieldId}*: ${value}`
+    .map(([fieldId, change]) =>
+      t("messages.field_change", {
+        field: fieldLabels[fieldId] ?? fieldId,
+        old: change.old || t("messages.no_changes"),
+        new: change.new,
+      })
     )
     .join("\n");
 
@@ -969,6 +981,32 @@ export default SlackFunction(
         };
       }
 
+      // Fetch current field values to show before/after diff
+      const userProfileResponse = await client.users.profile.get({
+        user: targetUserId,
+      });
+      const currentValues: Record<string, string> = {};
+      if (userProfileResponse.ok && userProfileResponse.profile?.fields) {
+        const profileFields = userProfileResponse.profile.fields as Record<
+          string,
+          { value?: string }
+        >;
+        for (const [fieldId, fieldData] of Object.entries(profileFields)) {
+          if (fieldData.value) {
+            currentValues[fieldId] = fieldData.value;
+          }
+        }
+      }
+
+      // Build changes with old and new values for diff display
+      const changes: Record<string, FieldChange> = {};
+      for (const [fieldId, newValue] of Object.entries(fieldUpdates)) {
+        changes[fieldId] = {
+          old: currentValues[fieldId] ?? "",
+          new: newValue,
+        };
+      }
+
       // Get Admin User Token
       const adminToken = env.SLACK_ADMIN_USER_TOKEN;
       if (!adminToken) {
@@ -1007,10 +1045,14 @@ export default SlackFunction(
 
         console.log(t("logs.custom_fields_updated"));
 
-        // Build changes text for notification
-        const changesText = Object.entries(fieldUpdates)
-          .map(([fieldId, value]) =>
-            `• *${fieldLabels[fieldId] ?? fieldId}*: ${value}`
+        // Build changes text with before → after diff for notification
+        const changesText = Object.entries(changes)
+          .map(([fieldId, change]) =>
+            t("messages.field_change", {
+              field: fieldLabels[fieldId] ?? fieldId,
+              old: change.old || t("messages.no_changes"),
+              new: change.new,
+            })
           )
           .join("\n");
 
@@ -1067,7 +1109,7 @@ export default SlackFunction(
         const blocks = buildApprovalMessage(
           operatorId,
           targetUserId,
-          fieldUpdates,
+          changes,
           fieldLabels,
           approverIds,
         );
@@ -1161,11 +1203,23 @@ export default SlackFunction(
         return;
       }
 
+      // Extract new values for API call (changes has { old, new } format)
+      const newValues: Record<string, string> = {};
+      for (const [fieldId, change] of Object.entries(changes)) {
+        if (typeof change === "object" && change !== null && "new" in change) {
+          const changeObj = change as { old: string; new: string };
+          newValues[fieldId] = changeObj.new;
+        } else {
+          // Fallback for old format (string value)
+          newValues[fieldId] = String(change);
+        }
+      }
+
       // Update custom fields
       console.log(t("logs.updating_custom_fields"));
       const result = await updateCustomFields(
         target_user_id,
-        changes,
+        newValues,
         adminToken,
       );
 
@@ -1215,11 +1269,23 @@ export default SlackFunction(
         text: approvedText,
       });
 
-      // Build changes text for notification
-      const changesText = Object.entries(changes as Record<string, string>)
-        .map(([fieldId, value]) =>
-          `• *${field_labels[fieldId] ?? fieldId}*: ${value}`
-        )
+      // Build changes text with before → after diff for notification
+      const changesText = Object.entries(changes)
+        .map(([fieldId, change]) => {
+          if (
+            typeof change === "object" && change !== null && "new" in change
+          ) {
+            const changeObj = change as { old: string; new: string };
+            return t("messages.field_change", {
+              field: field_labels[fieldId] ?? fieldId,
+              old: changeObj.old || t("messages.no_changes"),
+              new: changeObj.new,
+            });
+          } else {
+            // Fallback for old format
+            return `• ${field_labels[fieldId] ?? fieldId}: ${String(change)}`;
+          }
+        })
         .join("\n");
 
       // Notify requester via DM

--- a/functions/show_custom_fields_form/mod.ts
+++ b/functions/show_custom_fields_form/mod.ts
@@ -998,12 +998,28 @@ export default SlackFunction(
         }
       }
 
+      // Debug: Log form values vs current values
+      console.log("[ViewSubmissionHandler] Field updates:", fieldUpdates);
+      console.log("[ViewSubmissionHandler] Current values:", currentValues);
+
       // Build changes with old and new values for diff display
+      // Only include fields where the value actually changed
       const changes: Record<string, FieldChange> = {};
       for (const [fieldId, newValue] of Object.entries(fieldUpdates)) {
-        changes[fieldId] = {
-          old: currentValues[fieldId] ?? "",
-          new: newValue,
+        const oldValue = currentValues[fieldId] ?? "";
+        if (newValue !== oldValue) {
+          changes[fieldId] = {
+            old: oldValue,
+            new: newValue,
+          };
+        }
+      }
+
+      // If no actual changes, show error
+      if (Object.keys(changes).length === 0) {
+        return {
+          response_action: "errors",
+          errors: { target_user_block: t("errors.no_fields_to_update") },
         };
       }
 
@@ -1056,11 +1072,15 @@ export default SlackFunction(
           )
           .join("\n");
 
-        // Send success notification via DM to operator
+        // Send success notification via DM to operator with changes
         await sendDirectMessage(
           client as unknown as SlackClient,
           operatorId,
-          t("messages.custom_fields_updated"),
+          t("messages.custom_fields_update_notification", {
+            target: targetUserId,
+            updater: operatorId,
+            changes: changesText,
+          }),
         );
 
         // Send channel notification to the source channel

--- a/functions/show_custom_fields_form/mod.ts
+++ b/functions/show_custom_fields_form/mod.ts
@@ -1085,7 +1085,11 @@ export default SlackFunction(
 
         // Send channel notification to the source channel
         if (sourceChannelId) {
-          await client.chat.postMessage({
+          console.log(
+            "[ViewSubmissionHandler] Sending channel notification to:",
+            sourceChannelId,
+          );
+          const channelResult = await client.chat.postMessage({
             channel: sourceChannelId,
             text: t("messages.custom_fields_update_notification", {
               target: targetUserId,
@@ -1093,6 +1097,15 @@ export default SlackFunction(
               changes: changesText,
             }),
           });
+          console.log(
+            "[ViewSubmissionHandler] Channel notification result:",
+            channelResult.ok,
+            channelResult.error,
+          );
+        } else {
+          console.log(
+            "[ViewSubmissionHandler] No source channel ID, skipping channel notification",
+          );
         }
 
         // Complete the function

--- a/functions/show_profile_update_form/mod.ts
+++ b/functions/show_profile_update_form/mod.ts
@@ -1074,7 +1074,11 @@ export default SlackFunction(
 
         // Send channel notification to the source channel
         if (sourceChannelId) {
-          await client.chat.postMessage({
+          console.log(
+            "[ViewSubmissionHandler] Sending channel notification to:",
+            sourceChannelId,
+          );
+          const channelResult = await client.chat.postMessage({
             channel: sourceChannelId,
             text: t("messages.update_success_notification", {
               target: targetUserId,
@@ -1082,6 +1086,15 @@ export default SlackFunction(
               changes: changesText,
             }),
           });
+          console.log(
+            "[ViewSubmissionHandler] Channel notification result:",
+            channelResult.ok,
+            channelResult.error,
+          );
+        } else {
+          console.log(
+            "[ViewSubmissionHandler] No source channel ID, skipping channel notification",
+          );
         }
 
         // Complete the function

--- a/functions/show_profile_update_form/mod.ts
+++ b/functions/show_profile_update_form/mod.ts
@@ -968,21 +968,31 @@ export default SlackFunction(
       );
       const currentProfile = currentProfileResult.profile ?? {};
 
+      // Debug: Log form values vs current profile
+      console.log("[ViewSubmissionHandler] Form values:", {
+        displayName,
+        title,
+        phone,
+        pronouns,
+      });
+      console.log("[ViewSubmissionHandler] Current profile:", currentProfile);
+
       // Build profile changes with old and new values for diff display
+      // Only include fields where the value actually changed
       const changes: Record<string, ProfileChange> = {};
-      if (displayName) {
+      if (displayName && displayName !== (currentProfile.display_name ?? "")) {
         changes.display_name = {
           old: currentProfile.display_name ?? "",
           new: displayName,
         };
       }
-      if (title) {
+      if (title && title !== (currentProfile.title ?? "")) {
         changes.title = { old: currentProfile.title ?? "", new: title };
       }
-      if (phone) {
+      if (phone && phone !== (currentProfile.phone ?? "")) {
         changes.phone = { old: currentProfile.phone ?? "", new: phone };
       }
-      if (pronouns) {
+      if (pronouns && pronouns !== (currentProfile.pronouns ?? "")) {
         changes.pronouns = {
           old: currentProfile.pronouns ?? "",
           new: pronouns,
@@ -1051,12 +1061,14 @@ export default SlackFunction(
           )
           .join("\n");
 
-        // Send success notification via DM to operator
+        // Send success notification via DM to operator with changes
         await sendDirectMessage(
           client,
           operatorId,
-          t("messages.profile_updated_for_user", {
-            userId: targetUserId,
+          t("messages.update_success_notification", {
+            target: targetUserId,
+            updater: operatorId,
+            changes: changesText,
           }),
         );
 

--- a/functions/show_profile_update_form/mod.ts
+++ b/functions/show_profile_update_form/mod.ts
@@ -1241,39 +1241,6 @@ export default SlackFunction(
         return;
       }
 
-      // Update the message to show approval
-      const approvedText = t("messages.request_approved", {
-        approver: reviewerId,
-        requester: requester_id,
-        target: target_user_id,
-      });
-
-      await client.chat.update({
-        channel: body.channel?.id ?? "",
-        ts: body.message?.ts ?? "",
-        blocks: [
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: approvedText,
-            },
-          },
-          {
-            type: "context",
-            elements: [
-              {
-                type: "mrkdwn",
-                text: t("messages.approved_at", {
-                  time: new Date().toISOString(),
-                }),
-              },
-            ],
-          },
-        ],
-        text: approvedText,
-      });
-
       // Build changes text with before → after diff
       const changesText = Object.entries(changes)
         .map(([field, change]) => {
@@ -1292,6 +1259,46 @@ export default SlackFunction(
           }
         })
         .join("\n");
+
+      // Update the message to show approval with changes
+      const approvedText = t("messages.request_approved", {
+        approver: reviewerId,
+        requester: requester_id,
+        target: target_user_id,
+      });
+
+      await client.chat.update({
+        channel: body.channel?.id ?? "",
+        ts: body.message?.ts ?? "",
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: approvedText,
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `*${t("messages.changes_label")}:*\n${changesText}`,
+            },
+          },
+          {
+            type: "context",
+            elements: [
+              {
+                type: "mrkdwn",
+                text: t("messages.approved_at", {
+                  time: new Date().toISOString(),
+                }),
+              },
+            ],
+          },
+        ],
+        text: approvedText,
+      });
 
       // Notify requester via DM
       await sendDirectMessage(

--- a/functions/show_profile_update_form/mod.ts
+++ b/functions/show_profile_update_form/mod.ts
@@ -38,6 +38,14 @@ interface UserProfile {
 }
 
 /**
+ * Profile change with old and new values for diff display
+ */
+interface ProfileChange {
+  old: string;
+  new: string;
+}
+
+/**
  * Function definition for ShowProfileUpdateForm
  */
 export const ShowProfileUpdateFormDefinition = DefineFunction({
@@ -384,12 +392,18 @@ function buildProfileFormView(
 function buildApprovalMessage(
   requesterId: string,
   targetUserId: string,
-  changes: Record<string, string>,
+  changes: Record<string, ProfileChange>,
   reason?: string,
   approverIds?: string[],
 ) {
   const changesText = Object.entries(changes)
-    .map(([field, value]) => `• *${field}*: ${value}`)
+    .map(([field, change]) =>
+      t("messages.field_change", {
+        field,
+        old: change.old || t("messages.no_changes"),
+        new: change.new,
+      })
+    )
     .join("\n");
 
   const approverMentions = approverIds?.map((id) => `<@${id}>`).join(", ") ??
@@ -947,12 +961,33 @@ export default SlackFunction(
         ) ?? [];
       const reason = values.reason_block?.reason?.value ?? "";
 
-      // Build profile changes
-      const changes: Record<string, string> = {};
-      if (displayName) changes.display_name = displayName;
-      if (title) changes.title = title;
-      if (phone) changes.phone = phone;
-      if (pronouns) changes.pronouns = pronouns;
+      // Fetch current profile to show before/after diff
+      const currentProfileResult = await fetchUserProfile(
+        client as unknown as SlackClient,
+        targetUserId,
+      );
+      const currentProfile = currentProfileResult.profile ?? {};
+
+      // Build profile changes with old and new values for diff display
+      const changes: Record<string, ProfileChange> = {};
+      if (displayName) {
+        changes.display_name = {
+          old: currentProfile.display_name ?? "",
+          new: displayName,
+        };
+      }
+      if (title) {
+        changes.title = { old: currentProfile.title ?? "", new: title };
+      }
+      if (phone) {
+        changes.phone = { old: currentProfile.phone ?? "", new: phone };
+      }
+      if (pronouns) {
+        changes.pronouns = {
+          old: currentProfile.pronouns ?? "",
+          new: pronouns,
+        };
+      }
 
       if (Object.keys(changes).length === 0) {
         return {
@@ -987,7 +1022,13 @@ export default SlackFunction(
           };
         }
 
-        const result = await updateProfile(targetUserId, changes, adminToken);
+        // Extract new values for API call
+        const newValues: Record<string, string> = {};
+        for (const [field, change] of Object.entries(changes)) {
+          newValues[field] = change.new;
+        }
+
+        const result = await updateProfile(targetUserId, newValues, adminToken);
         if (!result.ok) {
           return {
             response_action: "errors",
@@ -999,9 +1040,15 @@ export default SlackFunction(
           };
         }
 
-        // Build changes text for notification
+        // Build changes text with before → after diff for notification
         const changesText = Object.entries(changes)
-          .map(([field, value]) => `• *${field}*: ${value}`)
+          .map(([field, change]) =>
+            t("messages.field_change", {
+              field,
+              old: change.old || t("messages.no_changes"),
+              new: change.new,
+            })
+          )
           .join("\n");
 
         // Send success notification via DM to operator
@@ -1144,8 +1191,20 @@ export default SlackFunction(
         return;
       }
 
+      // Extract new values for API call (changes has { old, new } format)
+      const newValues: Record<string, string> = {};
+      for (const [field, change] of Object.entries(changes)) {
+        if (typeof change === "object" && change !== null && "new" in change) {
+          const changeObj = change as { old: string; new: string };
+          newValues[field] = changeObj.new;
+        } else {
+          // Fallback for old format (string value)
+          newValues[field] = String(change);
+        }
+      }
+
       // Update profile
-      const result = await updateProfile(target_user_id, changes, adminToken);
+      const result = await updateProfile(target_user_id, newValues, adminToken);
       if (!result.ok) {
         await client.chat.postEphemeral({
           channel: body.channel?.id ?? "",
@@ -1190,6 +1249,25 @@ export default SlackFunction(
         text: approvedText,
       });
 
+      // Build changes text with before → after diff
+      const changesText = Object.entries(changes)
+        .map(([field, change]) => {
+          if (
+            typeof change === "object" && change !== null && "new" in change
+          ) {
+            const changeObj = change as { old: string; new: string };
+            return t("messages.field_change", {
+              field,
+              old: changeObj.old || t("messages.no_changes"),
+              new: changeObj.new,
+            });
+          } else {
+            // Fallback for old format
+            return `• ${field}: ${String(change)}`;
+          }
+        })
+        .join("\n");
+
       // Notify requester via DM
       await sendDirectMessage(
         client,
@@ -1197,9 +1275,7 @@ export default SlackFunction(
         t("messages.update_success_notification", {
           target: target_user_id,
           updater: reviewerId,
-          changes: Object.entries(changes).map(([k, v]) => `• ${k}: ${v}`).join(
-            "\n",
-          ),
+          changes: changesText,
         }),
       );
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -66,6 +66,7 @@
     "custom_fields_approval_request_details": "*Requester:* <@{requester}>\n*Target User:* <@{target}>\n*Changes:*\n{changes}",
     "approval_request_dm": "📝 A new approval request has been sent to you\n\n*Requester:* <@{requester}>\n*Target User:* <@{target}>\n\nPlease approve or deny in the approval channel.",
     "no_changes": "No changes",
+    "changes_label": "Changes",
     "field_change": "• {field}: {old} → {new}",
     "loading_form": "⏳ Loading form...",
     "processing": "Processing...",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -66,6 +66,7 @@
     "custom_fields_approval_request_details": "*リクエスター:* <@{requester}>\n*対象ユーザー:* <@{target}>\n*変更内容:*\n{changes}",
     "approval_request_dm": "📝 新しい承認リクエストがあなたに送信されました\n\n*リクエスター:* <@{requester}>\n*対象ユーザー:* <@{target}>\n\n承認チャンネルで承認または却下してください。",
     "no_changes": "変更なし",
+    "changes_label": "変更内容",
     "field_change": "• {field}: {old} → {new}",
     "loading_form": "⏳ フォームを読み込み中...",
     "processing": "処理中...",


### PR DESCRIPTION
## Summary
- 承認メッセージと変更通知メッセージにbefore → after形式の差分表示を追加
- プロフィール更新フォームとカスタムフィールドフォームの両方に対応

## Changes
- `ProfileChange`/`FieldChange`型を追加して、古い値と新しい値を追跡
- ViewSubmissionHandlerで変更を収集する前に現在のプロファイル/フィールド値を取得
- `buildApprovalMessage`関数を更新して`field_change`ロケールキーを使用したdiff形式で表示
- APPROVE_ACTION_IDハンドラーを更新して通知にdiffを表示

## Message Format

**Before:**
```
• display_name: 新しい名前
```

**After:**
```
• display_name: 古い名前 → 新しい名前
```

## Test plan
- [x] 全101テストがパス
- [x] deno fmt チェック通過
- [x] deno lint チェック通過
- [ ] プロフィール更新の承認メッセージにdiffが表示される
- [ ] カスタムフィールドの承認メッセージにdiffが表示される
- [ ] 変更通知にdiffが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)